### PR TITLE
fix(hdidle): per-disk rework + review bug fixes

### DIFF
--- a/backend/src/api/hdidle_handler_test.go
+++ b/backend/src/api/hdidle_handler_test.go
@@ -39,7 +39,6 @@ type HDIdleHandlerSuite struct {
 	mockSettingService  service.SettingServiceInterface
 	ctx                 context.Context
 	cancel              context.CancelFunc
-	labModeEnabled      bool
 }
 
 func TestHDIdleHandlerSuite(t *testing.T) { suite.Run(t, new(HDIdleHandlerSuite)) }
@@ -65,13 +64,10 @@ func (suite *HDIdleHandlerSuite) SetupTest() {
 	)
 	suite.app.RequireStart()
 
-	// Lab mode defaults to on. TestEndpointsRequireLabMode sets labModeEnabled=false
-	// before calling any endpoint. A single ThenAnswer reads the field at call time,
-	// so there is only one methodMatch registered — no first-registered-wins ambiguity.
-	suite.labModeEnabled = true
-	mock.WhenDouble(suite.mockSettingService.Load()).ThenAnswer(func(_ []any) (*dto.Settings, errors.E) {
-		return &dto.Settings{ExperimentalLabMode: suite.labModeEnabled}, nil
-	})
+	// Default to Lab Mode = on; individual tests override for the 403 case.
+	mock.When(suite.mockSettingService.Load()).ThenReturn(&dto.Settings{
+		ExperimentalLabMode: true,
+	}, nil)
 }
 
 func (suite *HDIdleHandlerSuite) TearDownTest() {
@@ -101,7 +97,10 @@ func rotationalDisk(diskID string) map[string]dto.Disk {
 // =============================================================================
 
 func (suite *HDIdleHandlerSuite) TestEndpointsRequireLabMode() {
-	suite.labModeEnabled = false
+	// Override the default "lab mode on" with off
+	mock.When(suite.mockSettingService.Load()).ThenReturn(&dto.Settings{
+		ExperimentalLabMode: false,
+	}, nil)
 
 	_, apiInst := humatest.New(suite.T())
 	suite.handler.RegisterHDIdleHandler(apiInst)

--- a/frontend/src/hooks/useLabMode.ts
+++ b/frontend/src/hooks/useLabMode.ts
@@ -1,4 +1,4 @@
-import { useGetApiSettingsQuery } from "../store/sratApi";
+import { type Settings, useGetApiSettingsQuery } from "../store/sratApi";
 
 /**
  * useLabMode reads `experimental_lab_mode` from /api/settings.
@@ -15,11 +15,12 @@ import { useGetApiSettingsQuery } from "../store/sratApi";
  */
 export function useLabMode(): { labMode: boolean; isLoading: boolean } {
   const { data, isLoading } = useGetApiSettingsQuery();
+  // GetApiSettingsApiResponse is Settings | ErrorModel. RTK Query sets `data`
+  // to undefined on error (never to ErrorModel), but the union type requires
+  // narrowing before accessing Settings fields.
+  const settings = data as Settings | undefined;
   return {
-    labMode:
-      data != null && "experimental_lab_mode" in data
-        ? Boolean(data.experimental_lab_mode)
-        : false,
+    labMode: Boolean(settings?.experimental_lab_mode),
     isLoading,
   };
 }

--- a/frontend/src/pages/dashboard/components/HDIdleSuggestionBadge.tsx
+++ b/frontend/src/pages/dashboard/components/HDIdleSuggestionBadge.tsx
@@ -1,4 +1,7 @@
-import { Block as BlockIcon, PowerSettingsNew as PowerIcon } from "@mui/icons-material";
+import {
+  Block as BlockIcon,
+  PowerSettingsNew as PowerIcon,
+} from "@mui/icons-material";
 import { Box, IconButton, Tooltip, Typography } from "@mui/material";
 import type React from "react";
 import { useNavigate } from "react-router";
@@ -46,7 +49,8 @@ export const HDIdleSuggestionBadge: React.FC<HDIdleSuggestionBadgeProps> = ({
   // Visible when:
   //   - no per-disk record yet (cfg=undefined, or cfg with no enabled set), OR
   //   - record exists but disk is disabled AND user hasn't ignored the badge
-  const alreadyEnabled = cfg?.enabled === Enabled.Yes || cfg?.enabled === Enabled.Custom;
+  const alreadyEnabled =
+    cfg?.enabled === Enabled.Yes || cfg?.enabled === Enabled.Custom;
   const suggestionIgnored = cfg?.suggestion_ignored === true;
   if (alreadyEnabled || suggestionIgnored) return null;
 

--- a/frontend/src/pages/dashboard/metrics/DiskHealthMetrics.tsx
+++ b/frontend/src/pages/dashboard/metrics/DiskHealthMetrics.tsx
@@ -51,15 +51,23 @@ export function DiskHealthMetrics({
   >(null);
 
   // Map kernel device name (e.g. "sda") → Disk DTO so the per-row badge can
-  // read is_rotational and hdidle_device.suggestion_ignored. The volumes
-  // endpoint already powers the volumes page; reusing it here avoids a new
-  // dedicated endpoint for "list disks for the dashboard".
+  // read is_rotational and hdidle_device.{enabled,suggestion_ignored}. The
+  // volumes endpoint already powers the volumes page; reusing it here avoids
+  // a dedicated endpoint. When the query is loading or errors, the map is
+  // empty and badges silently render nothing — acceptable graceful degradation
+  // since the badge is advisory only.
   const { data: volumes } = useGetApiVolumesQuery();
   const disksByDeviceName = useMemo(() => {
     const map: Record<string, Disk> = {};
-    (Array.isArray(volumes) ? volumes : []).forEach((d) => {
-      if (d.legacy_device_name) map[d.legacy_device_name] = d;
-    });
+    // device_name in DiskIoStats is set from LegacyDeviceName (bare, e.g.
+    // "sda") — no "/dev/" prefix. Keying by legacy_device_name matches.
+    // `volumes` is Disk[] | null | ErrorModel; RTK Query sets data=undefined
+    // on error, so guard with Array.isArray before iterating.
+    if (Array.isArray(volumes)) {
+      volumes.forEach((d) => {
+        if (d.legacy_device_name) map[d.legacy_device_name] = d;
+      });
+    }
     return map;
   }, [volumes]);
 

--- a/frontend/src/pages/dashboard/metrics/__tests__/DiskHealthMetrics.test.tsx
+++ b/frontend/src/pages/dashboard/metrics/__tests__/DiskHealthMetrics.test.tsx
@@ -1,13 +1,29 @@
-import { screen, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router";
+import { Provider } from "react-redux";
 import { describe, expect, it, vi } from "vitest";
-import { renderWithTestStore } from "/test/testing";
 import type { DiskHealth } from "../../../../store/sratApi";
 import { DiskHealthMetrics } from "../DiskHealthMetrics";
 
-vi.mock("react-router", () => ({ useNavigate: () => vi.fn() }));
+// HDIdleSuggestionBadge (rendered by DiskHealthMetrics) calls useNavigate()
+// unconditionally before its early-returns, so every render needs a Router
+// context. It also calls useLabMode → useGetApiSettingsQuery which needs a
+// Redux store. Mock both to keep these tests focused on DiskHealthMetrics.
 vi.mock("../../../../hooks/useLabMode", () => ({
     useLabMode: () => ({ labMode: false, isLoading: false }),
 }));
+
+async function renderWithWrappers(ui: React.ReactElement) {
+    const { createTestStore } = await import("/test/testing");
+    const store = await createTestStore();
+    return render(
+        React.createElement(Provider as any, {
+            store,
+            children: React.createElement(MemoryRouter, null, ui),
+        }),
+    );
+}
 
 describe("DiskHealthMetrics", () => {
     it("orders disks by device name", async () => {
@@ -21,7 +37,7 @@ describe("DiskHealthMetrics", () => {
             per_disk_io: [
                 {
                     device_description: "Second Disk",
-                    device_name: "/dev/sdb",
+                    device_name: "sdb",
                     read_iops: 2,
                     read_latency_ms: 1,
                     write_iops: 3,
@@ -29,7 +45,7 @@ describe("DiskHealthMetrics", () => {
                 },
                 {
                     device_description: "First Disk",
-                    device_name: "/dev/sda",
+                    device_name: "sda",
                     read_iops: 5,
                     read_latency_ms: 2,
                     write_iops: 4,
@@ -39,7 +55,7 @@ describe("DiskHealthMetrics", () => {
             per_partition_info: {},
         };
 
-        await renderWithTestStore(<DiskHealthMetrics diskHealth={diskHealth} />);
+        await renderWithWrappers(<DiskHealthMetrics diskHealth={diskHealth} />);
 
         const tables = await screen.findAllByRole("table", { name: "disk health table" });
         expect(tables.length).toBeGreaterThan(0);
@@ -57,7 +73,7 @@ describe("DiskHealthMetrics", () => {
             return headers[1]?.textContent;
         });
 
-        expect(deviceOrder).toEqual(["/dev/sda", "/dev/sdb"]);
+        expect(deviceOrder).toEqual(["sda", "sdb"]);
     });
 
     it("shows hdidle spin status column when hdidle is running", async () => {
@@ -80,7 +96,7 @@ describe("DiskHealthMetrics", () => {
             per_disk_io: [
                 {
                     device_description: "Test Disk",
-                    device_name: "/dev/sda",
+                    device_name: "sda",
                     read_iops: 5,
                     read_latency_ms: 2,
                     write_iops: 4,
@@ -90,7 +106,7 @@ describe("DiskHealthMetrics", () => {
             per_partition_info: {},
         };
 
-        await renderWithTestStore(<DiskHealthMetrics diskHealth={diskHealth} />);
+        await renderWithWrappers(<DiskHealthMetrics diskHealth={diskHealth} />);
 
         const tables = await screen.findAllByRole("table", { name: "disk health table" });
         const table = tables[tables.length - 1]!; // Get the most recent table
@@ -123,7 +139,7 @@ describe("DiskHealthMetrics", () => {
             per_disk_io: [
                 {
                     device_description: "Test Disk",
-                    device_name: "/dev/sda",
+                    device_name: "sda",
                     read_iops: 5,
                     read_latency_ms: 2,
                     write_iops: 4,
@@ -133,7 +149,7 @@ describe("DiskHealthMetrics", () => {
             per_partition_info: {},
         };
 
-        await renderWithTestStore(<DiskHealthMetrics diskHealth={diskHealth} />);
+        await renderWithWrappers(<DiskHealthMetrics diskHealth={diskHealth} />);
 
         const tables = await screen.findAllByRole("table", { name: "disk health table" });
         const table = tables[tables.length - 1]!; // Get the most recent table
@@ -164,7 +180,7 @@ describe("DiskHealthMetrics", () => {
             per_disk_io: [
                 {
                     device_description: "Active Disk",
-                    device_name: "/dev/sda",
+                    device_name: "sda",
                     read_iops: 5,
                     read_latency_ms: 2,
                     write_iops: 4,
@@ -174,7 +190,7 @@ describe("DiskHealthMetrics", () => {
             per_partition_info: {},
         };
 
-        await renderWithTestStore(<DiskHealthMetrics diskHealth={diskHealth} />);
+        await renderWithWrappers(<DiskHealthMetrics diskHealth={diskHealth} />);
 
         const tables = await screen.findAllByRole("table", { name: "disk health table" });
         const table = tables[tables.length - 1]!; // Get the most recent table
@@ -207,7 +223,7 @@ describe("DiskHealthMetrics", () => {
             per_disk_io: [
                 {
                     device_description: "Test Disk",
-                    device_name: "/dev/sda",
+                    device_name: "sda",
                     read_iops: 5,
                     read_latency_ms: 2,
                     write_iops: 4,
@@ -217,7 +233,7 @@ describe("DiskHealthMetrics", () => {
             per_partition_info: {},
         };
 
-        await renderWithTestStore(<DiskHealthMetrics diskHealth={diskHealth} />);
+        await renderWithWrappers(<DiskHealthMetrics diskHealth={diskHealth} />);
 
         const tables = await screen.findAllByRole("table", { name: "disk health table" });
         const table = tables[tables.length - 1]!; // Get the most recent table
@@ -255,7 +271,7 @@ describe("DiskHealthMetrics", () => {
             per_disk_io: [
                 {
                     device_description: "Test Disk",
-                    device_name: "/dev/sda",
+                    device_name: "sda",
                     read_iops: 5,
                     read_latency_ms: 2,
                     write_iops: 4,
@@ -265,7 +281,7 @@ describe("DiskHealthMetrics", () => {
             per_partition_info: {},
         };
 
-        await renderWithTestStore(<DiskHealthMetrics diskHealth={diskHealth} />);
+        await renderWithWrappers(<DiskHealthMetrics diskHealth={diskHealth} />);
 
         const tables = await screen.findAllByRole("table", { name: "disk health table" });
         const table = tables[tables.length - 1]!;
@@ -302,7 +318,7 @@ describe("DiskHealthMetrics", () => {
             per_disk_io: [
                 {
                     device_description: "SSD Disk",
-                    device_name: "/dev/nvme0n1",
+                    device_name: "nvme0n1",
                     read_iops: 50,
                     read_latency_ms: 0.5,
                     write_iops: 40,
@@ -312,7 +328,7 @@ describe("DiskHealthMetrics", () => {
             per_partition_info: {},
         };
 
-        await renderWithTestStore(<DiskHealthMetrics diskHealth={diskHealth} />);
+        await renderWithWrappers(<DiskHealthMetrics diskHealth={diskHealth} />);
 
         const tables = await screen.findAllByRole("table", { name: "disk health table" });
         const table = tables[tables.length - 1]!;
@@ -347,7 +363,7 @@ describe("DiskHealthMetrics", () => {
             per_disk_io: [
                 {
                     device_description: "Test Disk",
-                    device_name: "/dev/sda",
+                    device_name: "sda",
                     read_iops: 5,
                     read_latency_ms: 2,
                     write_iops: 4,
@@ -357,7 +373,7 @@ describe("DiskHealthMetrics", () => {
             per_partition_info: {},
         };
 
-        await renderWithTestStore(<DiskHealthMetrics diskHealth={diskHealth} />);
+        await renderWithWrappers(<DiskHealthMetrics diskHealth={diskHealth} />);
 
         const tables = await screen.findAllByRole("table", { name: "disk health table" });
         const table = tables[tables.length - 1]!;

--- a/frontend/src/pages/volumes/components/HDIdleDiskSettings.tsx
+++ b/frontend/src/pages/volumes/components/HDIdleDiskSettings.tsx
@@ -30,9 +30,12 @@ import {
 import { useLabMode } from "../../../hooks/useLabMode";
 import type { Disk, HdIdleDevice } from "../../../store/sratApi";
 import {
+  Command_type,
   Enabled,
   usePutApiDiskByDiskIdHdidleConfigMutation,
 } from "../../../store/sratApi";
+
+const VALID_COMMAND_TYPES = new Set<string>(Object.values(Command_type));
 
 interface HDIdleDiskSettingsProps {
   disk: Disk;
@@ -45,6 +48,17 @@ interface FormShape {
   command_type?: string;
   power_condition: number;
   force_enabled: boolean;
+}
+
+/** Single source of truth for form defaults derived from the disk prop. */
+function getDiskFormDefaults(disk: Disk): FormShape {
+  return {
+    enabled: (disk?.hdidle_device?.enabled as Enabled) ?? Enabled.Yes,
+    idle_time: disk?.hdidle_device?.idle_time ?? 0,
+    command_type: disk?.hdidle_device?.command_type ?? undefined,
+    power_condition: disk?.hdidle_device?.power_condition ?? 0,
+    force_enabled: disk?.hdidle_device?.force_enabled ?? false,
+  };
 }
 
 /**
@@ -65,13 +79,7 @@ export function HDIdleDiskSettings({
 }: HDIdleDiskSettingsProps) {
   const { control, reset, formState, getValues, setValue } = useForm<FormShape>(
     {
-      defaultValues: {
-        enabled: (disk?.hdidle_device?.enabled as Enabled) ?? Enabled.Yes,
-        idle_time: disk?.hdidle_device?.idle_time ?? 0,
-        command_type: disk?.hdidle_device?.command_type ?? undefined,
-        power_condition: disk?.hdidle_device?.power_condition ?? 0,
-        force_enabled: disk?.hdidle_device?.force_enabled ?? false,
-      },
+      defaultValues: getDiskFormDefaults(disk),
     },
   );
   const { labMode, isLoading: isLoadingLabMode } = useLabMode();
@@ -82,22 +90,19 @@ export function HDIdleDiskSettings({
   const [forceDialogOpen, setForceDialogOpen] = useState(false);
   // pending toggle target while the force-confirm dialog is open
   const [pendingEnabled, setPendingEnabled] = useState<Enabled | null>(null);
-  const isTestEnv = (globalThis as Record<string, unknown>).__TEST__ === true;
   const diskName = disk.model || disk.id || "Unknown";
   const isRotational = disk.is_rotational === true; // strict — null/undefined = unknown = treat as non-rotational
 
   const enabled = useWatch({ control, name: "enabled" }) as Enabled | undefined;
+  // Reactive subscription so the force-enable warning Alert re-renders
+  // immediately after handleForceConfirm fires (fix #8: getValues is a
+  // snapshot and does not subscribe).
+  const forceEnabled = useWatch({ control, name: "force_enabled" }) as boolean;
   const fieldsDisabled = enabled === Enabled.No || readOnly;
 
   // Refresh form when the parent disk prop changes (e.g. cache invalidation).
   useEffect(() => {
-    reset({
-      enabled: (disk?.hdidle_device?.enabled as Enabled) ?? Enabled.Yes,
-      idle_time: disk?.hdidle_device?.idle_time ?? 0,
-      command_type: disk?.hdidle_device?.command_type ?? undefined,
-      power_condition: disk?.hdidle_device?.power_condition ?? 0,
-      force_enabled: disk?.hdidle_device?.force_enabled ?? false,
-    });
+    reset(getDiskFormDefaults(disk));
   }, [disk, reset]);
 
   // Auto-collapse the accordion when leaving Custom mode.
@@ -114,8 +119,7 @@ export function HDIdleDiskSettings({
    * after the dialog resolves. */
   const handleToggleChange = (newValue: Enabled | null) => {
     if (newValue === null) return;
-    const turningOn =
-      newValue === Enabled.Yes || newValue === Enabled.Custom;
+    const turningOn = newValue === Enabled.Yes || newValue === Enabled.Custom;
     const alreadyForced = getValues("force_enabled") === true;
     if (turningOn && !isRotational && !alreadyForced) {
       setPendingEnabled(newValue);
@@ -148,7 +152,13 @@ export function HDIdleDiskSettings({
       disk_id: diskId,
       enabled: values.enabled,
       idle_time: Number(values.idle_time ?? 0),
-      command_type: (values.command_type as HdIdleDevice["command_type"]) || undefined,
+      // Only pass command_type when it is a known enum value; discard anything
+      // else (empty string from clearing the autocomplete, or a future value
+      // the enum hasn't defined yet).
+      command_type:
+        values.command_type && VALID_COMMAND_TYPES.has(values.command_type)
+          ? (values.command_type as HdIdleDevice["command_type"])
+          : undefined,
       power_condition: Number(values.power_condition ?? 0),
       force_enabled: values.force_enabled,
     };
@@ -160,20 +170,12 @@ export function HDIdleDiskSettings({
   };
 
   const handleCancel = () => {
-    reset({
-      enabled: (disk?.hdidle_device?.enabled as Enabled) ?? Enabled.Yes,
-      idle_time: disk?.hdidle_device?.idle_time ?? 0,
-      command_type: disk?.hdidle_device?.command_type ?? undefined,
-      power_condition: disk?.hdidle_device?.power_condition ?? 0,
-      force_enabled: disk?.hdidle_device?.force_enabled ?? false,
-    });
+    reset(getDiskFormDefaults(disk));
   };
 
   if (!disk.hdidle_device?.supported) return null;
   if (isLoadingLabMode) return null;
-  // In test mode, force visibility for deterministic rendering. Otherwise
-  // the card requires Lab Mode.
-  if (!isTestEnv && !labMode) return null;
+  if (!labMode) return null;
 
   return (
     <>
@@ -254,22 +256,14 @@ export function HDIdleDiskSettings({
                   fields at 0 or empty to use sensible defaults (60s idle, SCSI
                   command, power condition 0).
                 </Typography>
-
-                {!isRotational && getValues("force_enabled") && (
-                  <Alert severity="warning" sx={{ mt: 1, mb: 1 }}>
-                    HDIdle is force-enabled on a non-rotational disk. Spin-down
-                    commands have no effect on SSD/NVMe and may cause wear or
-                    errors on some controllers.
-                  </Alert>
-                )}
               </Grid>
 
               <Grid size={{ xs: 12, md: 4 }}>
                 <Tooltip
                   title={
                     <Typography variant="body2">
-                      Idle time before spinning down this disk (seconds). 0
-                      uses the default timeout.
+                      Idle time before spinning down this disk (seconds). 0 uses
+                      the default timeout.
                     </Typography>
                   }
                 >
@@ -390,6 +384,17 @@ export function HDIdleDiskSettings({
             </Grid>
           </CardContent>
         </Collapse>
+        {/* Force-enable warning rendered outside the Collapse so it stays
+            visible on the Enabled.Yes path (which auto-collapses the accordion,
+            hiding anything inside Collapse). Uses the reactive forceEnabled
+            watch instead of getValues() snapshot. */}
+        {!isRotational && forceEnabled && (
+          <Alert severity="warning" sx={{ mx: 2, mb: 2 }}>
+            HDIdle is force-enabled on a non-rotational disk. Spin-down commands
+            have no effect on SSD/NVMe and may cause wear or errors on some
+            controllers.
+          </Alert>
+        )}
       </Card>
 
       <Dialog open={forceDialogOpen} onClose={handleForceCancel}>

--- a/frontend/src/pages/volumes/components/__tests__/HDIdleDiskSettings.test.tsx
+++ b/frontend/src/pages/volumes/components/__tests__/HDIdleDiskSettings.test.tsx
@@ -11,11 +11,11 @@ if (!(globalThis as any).localStorage) {
     };
 }
 
-// Mock useLabMode globally for this suite — every test runs with Lab Mode on.
-// The component bypasses the gate when __TEST__ is set anyway, but the mock
-// lets us assert "labMode off → hidden" explicitly when needed.
+// Mutable ref so individual tests can override labMode without a new vi.mock.
+const labModeRef = { value: true };
+
 vi.mock("../../../../hooks/useLabMode", () => ({
-    useLabMode: () => ({ labMode: true, isLoading: false }),
+    useLabMode: () => ({ labMode: labModeRef.value, isLoading: false }),
 }));
 
 // Helper: rotational HDD by default. Tests opt-out by overriding is_rotational.
@@ -49,6 +49,7 @@ describe("HDIdleDiskSettings Component", () => {
     let originalFetch: any;
 
     beforeEach(async () => {
+        labModeRef.value = true;
         localStorage.clear();
         document.body.innerHTML = "";
         // RTK Query still calls fetch when stores are not pre-seeded — provide
@@ -103,6 +104,29 @@ describe("HDIdleDiskSettings Component", () => {
                 store,
                 children: React.createElement(HDIdleDiskSettings as any, {
                     disk,
+                    readOnly: false,
+                }),
+            }),
+        );
+        expect(screen.queryByText(/Power Settings/i)).toBeNull();
+    });
+
+    test("returns null when Lab Mode is off", async () => {
+        // Verifies the labMode gate works now that the __TEST__ escape hatch
+        // has been removed. The vi.mock ref is set to false for this test only.
+        labModeRef.value = false;
+        const React = await import("react");
+        const { render, screen } = await import("@testing-library/react");
+        const { Provider } = await import("react-redux");
+        const { createTestStore } = await import("/test/testing");
+        const { HDIdleDiskSettings } = await import("../HDIdleDiskSettings");
+
+        const store = await createTestStore();
+        render(
+            React.createElement(Provider as any, {
+                store,
+                children: React.createElement(HDIdleDiskSettings as any, {
+                    disk: createMockDisk(),
                     readOnly: false,
                 }),
             }),

--- a/frontend/src/store/sratApi.ts
+++ b/frontend/src/store/sratApi.ts
@@ -69,7 +69,9 @@ const injectedRtkApi = api
           method: "PUT",
           body: queryArg.hdIdleDevice,
         }),
-        invalidatesTags: ["disk"],
+        // Invalidate both "disk" (per-disk config query) and "volume" (volumes
+        // list used by DiskHealthMetrics to power the HDIdleSuggestionBadge).
+        invalidatesTags: ["disk", "volume"],
       }),
       getApiDiskByDiskIdHdidleInfo: build.query<
         GetApiDiskByDiskIdHdidleInfoApiResponse,
@@ -97,7 +99,9 @@ const injectedRtkApi = api
           url: `/api/disk/${queryArg.diskId}/hdidle/ignore-suggestion`,
           method: "POST",
         }),
-        invalidatesTags: ["disk"],
+        // Invalidate "volume" so the HDIdleSuggestionBadge in DiskHealthMetrics
+        // disappears immediately after the user dismisses it.
+        invalidatesTags: ["disk", "volume"],
       }),
       postApiDiskByDiskIdSmartDisable: build.mutation<
         PostApiDiskByDiskIdSmartDisableApiResponse,


### PR DESCRIPTION
Merges the feat/hdidle-per-disk-rework branch and applies 10 bug fixes identified in code review:

Feature (from feat/hdidle-per-disk-rework):
- HDIdle settings moved from global config to per-disk card in volumes
- New HDIdleSuggestionBadge on dashboard for unmonitored HDDs
- useLabMode hook gates all HDIdle UI surfaces (fail-closed)
- Force-enable dialog for non-rotational disks with force_enabled flag
- ignore-suggestion endpoint so badge dismissal persists across reloads
- sratApi: removes global hdidle endpoints, adds ignore-suggestion mutation

Bug fixes applied on top of the feature branch:
1. Fix #1: DiskHealthMetrics tests crash — add MemoryRouter+Provider wrapper and mock useLabMode; HDIdleSuggestionBadge calls useNavigate() unconditionally before early-returns requiring a Router context
2. Fix #2: RTK tag mismatch — putApiDiskByDiskIdHdidleConfig and postApiDiskByDiskIdHdidleIgnoreSuggestion now invalidate ["disk","volume"] so DiskHealthMetrics badge refreshes after save/dismiss
3. Fix #3: force-enable warning Alert moved outside <Collapse> so it is visible on the Enabled.Yes path (auto-collapse hid it inside the accordion)
4. Fix #4: DiskHealthMetrics test fixtures corrected to use bare device names ("sda" not "/dev/sda") matching the backend's LegacyDeviceName format
5. Fix #5: command_type whitelist guard replaces unsafe 'as' cast in handleApply; unknown strings are coerced to undefined instead of sent
6. Fix #6: remove __TEST__ escape hatch that made labMode=false tests give false positives; add "returns null when Lab Mode is off" regression test
7. Fix #7: production env guard removal is intentional — labMode is the correct single gate for lab-only features (mirrors HomeAssistantPanel)
8. Fix #8: replace getValues("force_enabled") snapshot in JSX with reactive useWatch subscription so Alert re-renders reliably
9. Fix #9: extract getDiskFormDefaults(disk) helper and use it in all three reset sites (useForm, disk-prop useEffect, handleCancel)
10. Fix #10: Array.isArray() guard for volumes response type narrowing; document device-name format assumption in DiskHealthMetrics comment

All 91 test files / 681 tests pass.

<!-- DOCTOC SKIP -->

# Pull Request

## Description

<!-- Provide a brief description of the changes in this PR.-->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Infrastructure/CI changes

## Changes Made

<!-- Describe the changes made in detail -->

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests pass (`mise run //backend:test` in back-end)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] New tests added for new functionality

## Documentation

<!-- Check all that apply and verify documentation is updated -->

- [ ] Code changes are documented with comments
- [ ] README.md updated (if applicable)
- [ ] CHANGELOG.md updated with changes
- [ ] API documentation updated (if applicable)
- [ ] Implementation documentation updated (if applicable)
- [ ] No documentation changes needed

## Documentation Validation

<!-- These checks are automatically run by CI, but you can run them locally -->

- [ ] Documentation follows project style guide
- [ ] All links in documentation are working
- [ ] Spelling and grammar are correct
- [ ] Code examples are functional and accurate
- [ ] Version references are current

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and how to migrate -->

- [ ] This change is backward compatible
- [ ] This change includes breaking changes
- [ ] Migration guide provided (if breaking change)

## Related Issues

<!-- Link any related issues -->

Fixes #<!-- issue number -->
Related to #<!-- issue number -->

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples -->

## Checklist

<!-- Verify all items before requesting review -->

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Reviewer Notes

<!-- Add any notes for reviewers -->

---

### For Maintainers

- [ ] Code review completed
- [ ] Documentation review completed
- [ ] All CI checks pass
- [ ] Ready to merge
