### PR TITLE
feat(fe): unify panel layout with shared ResizableSplitView

### DIFF
--- a/frontend/src/components/ResizableSplitView.tsx
+++ b/frontend/src/components/ResizableSplitView.tsx
@@ -1,0 +1,237 @@
+import { Box, type BoxProps, useMediaQuery, useTheme } from "@mui/material";
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export const DEFAULT_LEFT_PANEL_PCT = 30;
+export const MIN_LEFT_PANEL_PCT = 15;
+export const MAX_LEFT_PANEL_PCT = 60;
+const RESIZE_KEYBOARD_STEP_PCT = 5;
+
+/**
+ * Custom attributes needed by the guided tour (reactour) selectors.
+ */
+export type TourDataTutorProps = {
+  "data-tutor"?: string;
+};
+
+/**
+ * Extra attributes spread onto a layout wrapper (e.g. tour anchors).
+ * Layout styling is controlled by the component itself.
+ */
+export type ResizableSplitViewPanelProps = Omit<BoxProps, "sx"> &
+  TourDataTutorProps;
+
+export interface ResizableSplitViewProps {
+  /**
+   * localStorage key used to persist the left panel width percentage.
+   * Keep it unique per page so each panel has an independent width.
+   */
+  storageKey: string;
+  /** Content rendered in the left (tree/navigation) panel. */
+  leftPanel: ReactNode;
+  /** Content rendered in the right (details) panel. */
+  rightPanel: ReactNode;
+  /** Initial left panel width in percent when nothing is persisted. */
+  defaultLeftPanelPct?: number;
+  /** Minimum left panel width in percent (defaults to 15). */
+  minLeftPanelPct?: number;
+  /** Maximum left panel width in percent (defaults to 60). */
+  maxLeftPanelPct?: number;
+  /** Extra props spread onto the layout container (e.g. tour anchors). */
+  containerProps?: ResizableSplitViewPanelProps;
+  /** Extra props spread onto the left panel wrapper. */
+  leftPanelProps?: ResizableSplitViewPanelProps;
+  /** Extra props spread onto the right panel wrapper. */
+  rightPanelProps?: ResizableSplitViewPanelProps;
+}
+
+/**
+ * Responsive two-panel layout shared by the Volumes, Shares and Users pages.
+ *
+ * - Mobile (xs): panels stack vertically full-width, matching the Shares layout.
+ * - sm and up: panels sit side by side and the left panel width can be resized
+ *   by dragging the divider (or with the ArrowLeft/ArrowRight keys), matching
+ *   the Volumes layout. The chosen width is persisted per `storageKey`.
+ */
+export function ResizableSplitView({
+  storageKey,
+  leftPanel,
+  rightPanel,
+  defaultLeftPanelPct = DEFAULT_LEFT_PANEL_PCT,
+  minLeftPanelPct = MIN_LEFT_PANEL_PCT,
+  maxLeftPanelPct = MAX_LEFT_PANEL_PCT,
+  containerProps,
+  leftPanelProps,
+  rightPanelProps,
+}: ResizableSplitViewProps) {
+  const theme = useTheme();
+  const isDesktop = useMediaQuery(theme.breakpoints.up("sm"));
+
+  const [leftPanelPct, setLeftPanelPct] = useState<number>(() => {
+    try {
+      const saved = localStorage.getItem(storageKey);
+      if (saved) {
+        const pct = parseFloat(saved);
+        if (
+          !Number.isNaN(pct) &&
+          pct >= minLeftPanelPct &&
+          pct <= maxLeftPanelPct
+        ) {
+          return pct;
+        }
+      }
+    } catch {}
+    return defaultLeftPanelPct;
+  });
+
+  const isDragging = useRef(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const applyPanelPct = useCallback(
+    (pct: number) => {
+      const clamped = Math.min(maxLeftPanelPct, Math.max(minLeftPanelPct, pct));
+      setLeftPanelPct(clamped);
+    },
+    [maxLeftPanelPct, minLeftPanelPct],
+  );
+
+  const handleDividerMouseDown = useCallback((e: ReactMouseEvent) => {
+    e.preventDefault();
+    isDragging.current = true;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, []);
+
+  const handleDividerKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+      e.preventDefault();
+      const delta =
+        e.key === "ArrowLeft"
+          ? -RESIZE_KEYBOARD_STEP_PCT
+          : RESIZE_KEYBOARD_STEP_PCT;
+      applyPanelPct(leftPanelPct + delta);
+    },
+    [applyPanelPct, leftPanelPct],
+  );
+
+  useEffect(() => {
+    const handleMouseMove = (e: globalThis.MouseEvent) => {
+      if (!isDragging.current || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const offsetX = e.clientX - rect.left;
+      const pct = (offsetX / rect.width) * 100;
+      applyPanelPct(pct);
+    };
+
+    const handleMouseUp = () => {
+      if (!isDragging.current) return;
+      isDragging.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [applyPanelPct]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(storageKey, String(leftPanelPct));
+    } catch {}
+  }, [storageKey, leftPanelPct]);
+
+  // Mobile: stack the panels full-width (Shares-style layout).
+  if (!isDesktop) {
+    return (
+      <Box
+        {...containerProps}
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+          minHeight: "calc(100vh - 200px)",
+        }}
+      >
+        <Box
+          {...leftPanelProps}
+          sx={{
+            width: "100%",
+          }}
+        >
+          {leftPanel}
+        </Box>
+        <Box
+          {...rightPanelProps}
+          sx={{
+            width: "100%",
+          }}
+        >
+          {rightPanel}
+        </Box>
+      </Box>
+    );
+  }
+
+  // Desktop: side-by-side panels with a resizable divider (Volumes-style).
+  return (
+    <Box
+      ref={containerRef}
+      {...containerProps}
+      sx={{
+        display: "flex",
+        minHeight: "calc(100vh - 200px)",
+        gap: 1,
+      }}
+    >
+      <Box
+        {...leftPanelProps}
+        sx={{
+          width: `${leftPanelPct}%`,
+          minWidth: 0,
+          flexShrink: 0,
+        }}
+      >
+        {leftPanel}
+      </Box>
+
+      <Box
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize panels"
+        aria-valuenow={Math.round(leftPanelPct)}
+        aria-valuemin={minLeftPanelPct}
+        aria-valuemax={maxLeftPanelPct}
+        tabIndex={0}
+        onMouseDown={handleDividerMouseDown}
+        onKeyDown={handleDividerKeyDown}
+        sx={{
+          width: 6,
+          flexShrink: 0,
+          cursor: "col-resize",
+          backgroundColor: "divider",
+          borderRadius: 1,
+          alignSelf: "stretch",
+          transition: "background-color 0.15s",
+          "&:hover": {
+            backgroundColor: "primary.main",
+          },
+        }}
+      />
+
+      <Box
+        {...rightPanelProps}
+        sx={{
+          flex: 1,
+          minWidth: 0,
+        }}
+      >
+        {rightPanel}
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/__tests__/ResizableSplitView.test.tsx
+++ b/frontend/src/components/__tests__/ResizableSplitView.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ResizableSplitView } from "../ResizableSplitView";
+
+const STORAGE_KEY = "test.splitPct";
+
+function createMatchMedia(matches: boolean) {
+  return () =>
+    ({
+      matches,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+      onchange: null,
+      media: "",
+    }) as any;
+}
+
+function renderSplitView(props: Record<string, unknown> = {}) {
+  return render(
+    <ResizableSplitView
+      storageKey={STORAGE_KEY}
+      leftPanel={<div>Left Panel</div>}
+      rightPanel={<div>Right Panel</div>}
+      {...props}
+    />,
+  );
+}
+
+describe("ResizableSplitView", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    // Desktop by default unless a test overrides it.
+    (window as any).matchMedia = createMatchMedia(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders both panels side by side with a divider on desktop", () => {
+    renderSplitView();
+
+    expect(screen.getByText("Left Panel")).toBeInTheDocument();
+    expect(screen.getByText("Right Panel")).toBeInTheDocument();
+    expect(screen.getByRole("separator")).toBeInTheDocument();
+  });
+
+  it("stacks the panels vertically without a divider on mobile", () => {
+    (window as any).matchMedia = createMatchMedia(false);
+
+    renderSplitView();
+
+    expect(screen.getByText("Left Panel")).toBeInTheDocument();
+    expect(screen.getByText("Right Panel")).toBeInTheDocument();
+    expect(screen.queryByRole("separator")).not.toBeInTheDocument();
+  });
+
+  it("restores a saved left panel width from localStorage", () => {
+    localStorage.setItem(STORAGE_KEY, "42");
+
+    renderSplitView();
+
+    expect(screen.getByRole("separator")).toHaveAttribute(
+      "aria-valuenow",
+      "42",
+    );
+  });
+
+  it("falls back to the default width when the saved value is out of range", () => {
+    localStorage.setItem(STORAGE_KEY, "999");
+
+    renderSplitView();
+
+    expect(screen.getByRole("separator")).toHaveAttribute(
+      "aria-valuenow",
+      "30",
+    );
+  });
+
+  it("falls back to the default width when the saved value is invalid", () => {
+    localStorage.setItem(STORAGE_KEY, "not-a-number");
+
+    renderSplitView();
+
+    expect(screen.getByRole("separator")).toHaveAttribute(
+      "aria-valuenow",
+      "30",
+    );
+  });
+
+  it("persists the width changed via the keyboard", async () => {
+    const user = userEvent.setup();
+    renderSplitView();
+
+    const divider = screen.getByRole("separator");
+    divider.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("35");
+    expect(divider).toHaveAttribute("aria-valuenow", "35");
+  });
+
+  it("decreases the width via the keyboard", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(STORAGE_KEY, "50");
+    renderSplitView();
+
+    const divider = screen.getByRole("separator");
+    divider.focus();
+    await user.keyboard("{ArrowLeft}");
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("45");
+    expect(divider).toHaveAttribute("aria-valuenow", "45");
+  });
+
+  it("clamps the keyboard resize to the configured minimum", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(STORAGE_KEY, "17");
+    renderSplitView();
+
+    const divider = screen.getByRole("separator");
+    divider.focus();
+    await user.keyboard("{ArrowLeft}{ArrowLeft}{ArrowLeft}");
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("15");
+  });
+
+  it("persists the width changed by dragging the divider", async () => {
+    const getBoundingClientRect = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValue({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 1000,
+        bottom: 600,
+        width: 1000,
+        height: 600,
+        toJSON: () => ({}),
+      } as DOMRect);
+    const user = userEvent.setup();
+    renderSplitView();
+
+    const divider = screen.getByRole("separator");
+    await user.pointer({ keys: "[MouseLeft>]", target: divider });
+    // Move the pointer to 45% of the container width.
+    await user.pointer({ coords: { x: 450, y: 300 } });
+    await user.pointer({ keys: "[/MouseLeft]" });
+
+    expect(getBoundingClientRect).toHaveBeenCalled();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("45");
+  });
+
+  it("honors a custom storage key so pages keep independent widths", () => {
+    localStorage.setItem("other.splitPct", "55");
+    renderSplitView({ storageKey: "other.splitPct" });
+
+    expect(screen.getByRole("separator")).toHaveAttribute(
+      "aria-valuenow",
+      "55",
+    );
+  });
+});

--- a/frontend/src/pages/shares/Shares.tsx
+++ b/frontend/src/pages/shares/Shares.tsx
@@ -1,7 +1,6 @@
 import AddIcon from "@mui/icons-material/Add";
 import {
   Box,
-  Grid,
   IconButton,
   Paper,
   Stack,
@@ -13,6 +12,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { toast } from "react-toastify";
 import { PreviewDialog } from "../../components/PreviewDialog";
+import { ResizableSplitView } from "../../components/ResizableSplitView";
 import { useShare } from "../../hooks/shareHook";
 import { useVolume } from "../../hooks/volumeHook";
 import { addMessage } from "../../store/errorSlice";
@@ -385,15 +385,13 @@ export function Shares() {
         }}
         onDeleteSubmit={onSubmitDeleteShare}
       />
-      {/* Main Layout Grid */}
-      <Grid
-        container
-        spacing={2}
-        sx={{ minHeight: "calc(100vh - 200px)" }}
-        data-tutor={`reactour__tab${TabIDs.SHARES}__step0`}
-      >
-        {/* Left Panel - Tree View */}
-        <Grid size={{ xs: 12, sm: 5, md: 4, lg: 3 }}>
+      {/* Main Layout */}
+      <ResizableSplitView
+        storageKey="shares.leftPanelPct"
+        containerProps={{
+          "data-tutor": `reactour__tab${TabIDs.SHARES}__step0`,
+        }}
+        leftPanel={
           <Paper
             sx={{ height: "100%", p: 1 }}
             data-tutor={`reactour__tab${TabIDs.SHARES}__step3`}
@@ -456,10 +454,8 @@ export function Shares() {
               onExpandedItemsChange={setExpandedGroups}
             />
           </Paper>
-        </Grid>
-
-        {/* Right Panel - Details and Edit Form */}
-        <Grid size={{ xs: 12, sm: 7, md: 8, lg: 9 }}>
+        }
+        rightPanel={
           <Paper sx={{ height: "100%", overflow: "hidden" }}>
             {selectedShare && selectedShareKey ? (
               <ShareDetailsPanel
@@ -502,8 +498,8 @@ export function Shares() {
               </Box>
             )}
           </Paper>
-        </Grid>
-      </Grid>
+        }
+      />
     </>
   );
 }

--- a/frontend/src/pages/users/Users.tsx
+++ b/frontend/src/pages/users/Users.tsx
@@ -1,7 +1,6 @@
 import AddIcon from "@mui/icons-material/Add";
 import {
   Box,
-  Grid,
   IconButton,
   Paper,
   Stack,
@@ -12,6 +11,7 @@ import { useConfirm } from "material-ui-confirm";
 import { useCallback, useEffect, useState } from "react";
 import { InView } from "react-intersection-observer";
 import { toast } from "react-toastify";
+import { ResizableSplitView } from "../../components/ResizableSplitView";
 import { TabIDs } from "../../store/locationState";
 import {
   type SharedResource,
@@ -271,15 +271,13 @@ export function Users() {
           }
         }}
       />
-      {/* Main Layout Grid */}
-      <Grid
-        container
-        spacing={2}
-        sx={{ minHeight: "calc(100vh - 200px)", mt: 1 }}
-        data-tutor={`reactour__tab${TabIDs.USERS}__step0`}
-      >
-        {/* Left Panel - Tree View */}
-        <Grid size={{ xs: 12, md: 4, lg: 3 }}>
+      {/* Main Layout */}
+      <ResizableSplitView
+        storageKey="users.leftPanelPct"
+        containerProps={{
+          "data-tutor": `reactour__tab${TabIDs.USERS}__step0`,
+        }}
+        leftPanel={
           <Paper
             sx={{ height: "100%", p: 1 }}
             data-tutor={`reactour__tab${TabIDs.USERS}__step1`}
@@ -327,10 +325,8 @@ export function Users() {
               onExpandedItemsChange={setExpandedGroups}
             />
           </Paper>
-        </Grid>
-
-        {/* Right Panel - Details and Edit Form */}
-        <Grid size={{ xs: 12, md: 8, lg: 9 }}>
+        }
+        rightPanel={
           <Paper sx={{ height: "100%", overflow: "hidden" }}>
             {selectedUser && selectedUserKey ? (
               <UserDetailsPanel
@@ -374,8 +370,8 @@ export function Users() {
               </Box>
             )}
           </Paper>
-        </Grid>
-      </Grid>
+        }
+      />
     </InView>
   );
 }

--- a/frontend/src/pages/volumes/Volumes.tsx
+++ b/frontend/src/pages/volumes/Volumes.tsx
@@ -7,17 +7,11 @@ import {
   Typography,
 } from "@mui/material";
 import { useConfirm } from "material-ui-confirm";
-import {
-  type MouseEvent as ReactMouseEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { toast } from "react-toastify";
 import { PreviewDialog } from "../../components/PreviewDialog";
+import { ResizableSplitView } from "../../components/ResizableSplitView";
 import { useVolume } from "../../hooks/volumeHook";
 import { type LocationState, TabIDs } from "../../store/locationState";
 import {
@@ -46,10 +40,6 @@ import {
   getDiskIdentifier,
   getPartitionIdentifier,
 } from "./utils";
-
-const MIN_LEFT_PANEL_PCT = 15;
-const MAX_LEFT_PANEL_PCT = 60;
-const DEFAULT_LEFT_PANEL_PCT = 30;
 
 export function updatePartitionLabelInDisks(
   disks: Disk[] | undefined,
@@ -133,67 +123,6 @@ export function Volumes({ initialDisks }: { initialDisks?: Disk[] } = {}) {
   const [umountVolume, _umountVolumeResult] = useDeleteApiVolumeMutation();
   const [patchMountSettings] = usePatchApiVolumeSettingsMutation();
   const loggedLoadErrorRef = useRef<string>("");
-
-  const [leftPanelPct, setLeftPanelPct] = useState<number>(() => {
-    try {
-      const saved = localStorage.getItem("volumes.leftPanelPct");
-      if (saved) {
-        const pct = parseFloat(saved);
-        if (
-          !Number.isNaN(pct) &&
-          pct >= MIN_LEFT_PANEL_PCT &&
-          pct <= MAX_LEFT_PANEL_PCT
-        ) {
-          return pct;
-        }
-      }
-    } catch {}
-    return DEFAULT_LEFT_PANEL_PCT;
-  });
-
-  const isDragging = useRef(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  const handleDividerMouseDown = useCallback((e: ReactMouseEvent) => {
-    e.preventDefault();
-    isDragging.current = true;
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-  }, []);
-
-  useEffect(() => {
-    const handleMouseMove = (e: globalThis.MouseEvent) => {
-      if (!isDragging.current || !containerRef.current) return;
-      const rect = containerRef.current.getBoundingClientRect();
-      const offsetX = e.clientX - rect.left;
-      const pct = (offsetX / rect.width) * 100;
-      const clamped = Math.min(
-        MAX_LEFT_PANEL_PCT,
-        Math.max(MIN_LEFT_PANEL_PCT, pct),
-      );
-      setLeftPanelPct(clamped);
-    };
-
-    const handleMouseUp = () => {
-      if (!isDragging.current) return;
-      isDragging.current = false;
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    };
-
-    window.addEventListener("mousemove", handleMouseMove);
-    window.addEventListener("mouseup", handleMouseUp);
-    return () => {
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseup", handleMouseUp);
-    };
-  }, []);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem("volumes.leftPanelPct", String(leftPanelPct));
-    } catch {}
-  }, [leftPanelPct]);
 
   useEffect(() => {
     setDisks(sourceDisks ?? []);
@@ -705,23 +634,15 @@ export function Volumes({ initialDisks }: { initialDisks?: Disk[] } = {}) {
           setShowPreview(false);
         }}
       />
-      <Box
-        ref={containerRef}
-        sx={{
-          display: "flex",
-          minHeight: "calc(100vh - 200px)",
-          gap: 1,
+      <ResizableSplitView
+        storageKey="volumes.leftPanelPct"
+        containerProps={{
+          "data-tutor": `reactour__tab${TabIDs.VOLUMES}__step0`,
         }}
-        data-tutor={`reactour__tab${TabIDs.VOLUMES}__step0`}
-      >
-        <Box
-          sx={{
-            width: { xs: "min(45%, 180px)", sm: `${leftPanelPct}%` },
-            minWidth: 0,
-            flexShrink: 0,
-          }}
-          data-tutor={`reactour__tab${TabIDs.VOLUMES}__step3`}
-        >
+        leftPanelProps={{
+          "data-tutor": `reactour__tab${TabIDs.VOLUMES}__step3`,
+        }}
+        leftPanel={
           <Paper sx={{ height: "100%", p: 1 }}>
             <Stack
               direction="row"
@@ -808,31 +729,11 @@ export function Volumes({ initialDisks }: { initialDisks?: Disk[] } = {}) {
               />
             )}
           </Paper>
-        </Box>
-
-        <Box
-          onMouseDown={handleDividerMouseDown}
-          sx={{
-            width: 6,
-            flexShrink: 0,
-            cursor: "col-resize",
-            backgroundColor: "divider",
-            borderRadius: 1,
-            alignSelf: "stretch",
-            transition: "background-color 0.15s",
-            "&:hover": {
-              backgroundColor: "primary.main",
-            },
-          }}
-        />
-
-        <Box
-          sx={{
-            flex: 1,
-            minWidth: 0,
-          }}
-          data-tutor={`reactour__tab${TabIDs.VOLUMES}__step4`}
-        >
+        }
+        rightPanelProps={{
+          "data-tutor": `reactour__tab${TabIDs.VOLUMES}__step4`,
+        }}
+        rightPanel={
           <Paper sx={{ height: "100%", overflow: "hidden" }}>
             <Box data-tutor={`reactour__tab${TabIDs.VOLUMES}__step5`}>
               <VolumeDetailsPanel
@@ -852,8 +753,8 @@ export function Volumes({ initialDisks }: { initialDisks?: Disk[] } = {}) {
               />
             </Box>
           </Paper>
-        </Box>
-      </Box>
+        }
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary

Extract the Volumes page's resizable two-panel layout into a shared `ResizableSplitView` component and use it on the Volumes, Shares and Users pages, unifying their layout so all three behave identically:

- **Mobile (xs)**: panels stack vertically full-width (the Shares layout, cleanest on phones).
- **sm and up**: side-by-side panels with a draggable divider (the Volumes layout), including keyboard support (`ArrowLeft`/`ArrowRight` ±5%) and per-page persisted widths via `localStorage`.

## What changed

- **`frontend/src/components/ResizableSplitView.tsx`** (new): responsive two-panel layout with mobile stacking, resizable divider, keyboard resize, min/max clamping (15–60%, default 30%) and localStorage persistence keyed per page.
- **`frontend/src/components/__tests__/ResizableSplitView.test.tsx`** (new): 10 tests covering desktop divider, mobile stacking, localStorage restore, out-of-range/invalid fallback, keyboard resize + persistence, min clamping, drag interaction and custom storage keys.
- **`frontend/src/pages/volumes/Volumes.tsx`**: replaced ~120 lines of inline drag/resize/persistence logic with the shared component (all 5 reactour anchors preserved).
- **`frontend/src/pages/shares/Shares.tsx`**: converted from `Grid` layout to the shared component (anchors preserved).
- **`frontend/src/pages/users/Users.tsx`**: converted from `Grid` layout to the shared component (anchors preserved, dropped stray `mt: 1`).

## Validation

- New component tests: 10/10, stable across reruns
- Full frontend suite: 738 passed / 1 skipped (happy-dom)
- Browser mobile smoke test (#922's, 375px Chromium, no horizontal overflow): passed
- `bun tsc --noEmit`: clean
- Biome + production build: clean

## Notes

- Rebased onto `main` and resolved the `Volumes.tsx` conflict with #922 (its xs `min(45%, 180px)` clamp is superseded by the component's full-width mobile stacking; the #922 overflow smoke test still passes).
- No task doc or GitHub issue is linked — this continues the UI unification work from #922.